### PR TITLE
Fix unbounded varint parsing. They are restricted to 4 bytes

### DIFF
--- a/src/mqtt_packet_map_decoder.erl
+++ b/src/mqtt_packet_map_decoder.erl
@@ -60,6 +60,10 @@ parse(MQTTVersion, VarSize, Fixed, VarData) when size(VarData) >= VarSize ->
     case variable(MQTTVersion, Fixed, Var) of
         {ok, Msg} ->
             {ok, {Msg, Rest}};
+        {error, incomplete_packet} ->
+            % Data was exhausted inside variable/3, but we had the full packet
+            % according to the fixed header. This means the packet is malformed.
+            {error, malformed_packet};
         {error, _} = Error ->
             Error
     end;
@@ -80,163 +84,192 @@ variable(_MQTTVersion,
            PropsRest/binary>>) ->
     case protocol_name_level(ProtocolName, ProtocolLevel) of
         {true, ProtoVersion} ->
-            {ok, {Properties, Rest}} = parse_properties(ProtoVersion, PropsRest),
-            {ClientId, Rest1} = parse_utf(Rest),
-            {ok, {WillProperties, Rest2}} = case WillFlag of
-                1 -> parse_properties(ProtoVersion, Rest1);
-                0 -> {ok, {#{}, Rest1}}
-            end,
-            {WillTopic,   Rest3} = parse_utf(Rest2, WillFlag),
-            {WillPayload, Rest4} = parse_msg(Rest3, WillFlag),
-            {Username,    Rest5} = parse_utf(Rest4, UserNameFlag),
-            {Password,    <<>>}  = parse_utf(Rest5, PasswordFlag),
-            case split_topic(WillTopic) of
-                {ok, WillTopicValidated} ->
-                    {ok, #{
-                        type => 'connect',
-                        protocol_name => ProtocolName,
-                        protocol_version => ProtoVersion,
-                        client_id => ClientId,
-                        clean_start => bool(CleanStart),
-                        keep_alive => KeepAlive,
-                        properties => Properties,
-                        username => Username,
-                        password => Password,
-                        will_flag => bool(WillFlag),
-                        will_retain => bool(WillRetain),
-                        will_qos => qos(WillQos),
-                        will_properties => WillProperties,
-                        will_topic => WillTopicValidated,
-                        will_payload => WillPayload
-                    }};
-                {error, _} = Error ->
-                    Error
-            end;
+            Connect = #{
+                type => 'connect',
+                protocol_name => ProtocolName,
+                protocol_version => ProtoVersion,
+                clean_start => bool(CleanStart),
+                keep_alive => KeepAlive,
+                will_flag => bool(WillFlag),
+                will_retain => bool(WillRetain),
+                will_qos => qos(WillQos)
+            },
+            decode_connect_properties(PropsRest, Connect, UserNameFlag, PasswordFlag);
         false ->
             {error, unknown_protocol}
     end;
 variable(_MQTTVersion, <<?CONNECT:4, 0:4>>, <<L:16/big, _PMagic:L/binary, _/binary>>) ->
     {error, unknown_protocol};
 variable(MQTTVersion, <<?CONNACK:4, 0:4>>, <<0:7, SessionPresent:1, ConnectReason:8, Rest/binary>>) ->
-    {ok, {Properties, <<>>}} = parse_properties(MQTTVersion, Rest),
-    {ok, #{
-        type => 'connack',
-        session_present => bool(SessionPresent),
-        reason_code => ConnectReason,
-        properties => Properties
-    }};
+    case parse_properties(MQTTVersion, Rest) of
+        {ok, {Properties, <<>>}} ->
+            {ok, #{
+                type => 'connack',
+                session_present => bool(SessionPresent),
+                reason_code => ConnectReason,
+                properties => Properties
+            }};
+        {error, _} = Err -> Err
+    end;
 variable(MQTTVersion, <<?PUBLISH:4, Dup:1, QoS:2, Retain:1>>, <<TopicLen:16/big, Topic:TopicLen/binary, Rest/binary>>) ->
     {PacketId, Rest2} = case QoS of
         0 ->
             {undefined, Rest};
         _ ->
-            <<PId:16/big, R/binary>> = Rest,
-            {PId, R}
+            case Rest of
+                <<PId:16/big, R/binary>> -> {PId, R};
+                _ -> {undefined, error}
+            end
     end,
-    {ok, {Properties, Payload}} = parse_properties(MQTTVersion, Rest2),
-    case split_topic(Topic) of
-        {ok, TopicValidated} ->
-            case mqtt_packet_map_topic:is_wildcard_topic(TopicValidated) of
-                false ->
-                    {ok, #{
-                        type => 'publish',
-                        dup => bool(Dup),
-                        qos => qos(QoS),
-                        retain => bool(Retain),
-                        topic => TopicValidated,
-                        packet_id => PacketId,
-                        properties => Properties,
-                        payload => Payload
-                    }};
-                true ->
-                    {error, invalid_topic}
-            end;
-        {error, _} = Error ->
-            Error
+    case PacketId of
+        undefined when Rest2 =:= error -> {error, incomplete_packet};
+        _ ->
+            case parse_properties(MQTTVersion, Rest2) of
+                {ok, {Properties, Payload}} ->
+                    case split_topic(Topic) of
+                        {ok, TopicValidated} ->
+                            case mqtt_packet_map_topic:is_wildcard_topic(TopicValidated) of
+                                false ->
+                                    {ok, #{
+                                        type => 'publish',
+                                        dup => bool(Dup),
+                                        qos => qos(QoS),
+                                        retain => bool(Retain),
+                                        topic => TopicValidated,
+                                        packet_id => PacketId,
+                                        properties => Properties,
+                                        payload => Payload
+                                    }};
+                                true ->
+                                    {error, invalid_topic}
+                            end;
+                        {error, _} = Error ->
+                            Error
+                    end;
+                {error, _} = ErrP -> ErrP
+            end
     end;
 variable(MQTTVersion, <<P:4, 0:4>>, <<PacketId:16/big, Rest/binary>>)
     when P =:= ?PUBACK; P =:= ?PUBREC; P =:= ?PUBCOMP ->
-    {ReasonCode, Properties} = case MQTTVersion of
+    Res = case MQTTVersion of
         ?MQTTv5 when Rest =:= <<>> ->
-            {?MQTT_RC_SUCCESS, #{}};
+            {ok, {?MQTT_RC_SUCCESS, #{}}};
         ?MQTTv5 ->
-            <<RC:8, Rest1/binary>> = Rest,
-            {ok, {Ps, <<>>}} = parse_properties(Rest1),
-            {RC, Ps};
+            case Rest of
+                <<RC:8, Rest1/binary>> ->
+                    case parse_properties(Rest1) of
+                        {ok, {Ps, <<>>}} -> {ok, {RC, Ps}};
+                        {error, _} = ErrP -> ErrP
+                    end;
+                _ -> {error, incomplete_packet}
+            end;
         _ when Rest =:= <<>> ->
-            {?MQTT_RC_SUCCESS, #{}}
+            {ok, {?MQTT_RC_SUCCESS, #{}}}
     end,
-    {ok, #{
-        type => case P of
-                    ?PUBACK -> 'puback';
-                    ?PUBREC -> 'pubrec';
-                    ?PUBCOMP -> 'pubcomp'
-                end,
-        packet_id => PacketId,
-        reason_code => ReasonCode,
-        properties => Properties
-    }};
-variable(MQTTVersion, <<?PUBREL:4, 2:4>>, <<PacketId:16/big, Rest/binary>>) ->
-    {ReasonCode, Properties} = case MQTTVersion of
-        ?MQTTv5 when Rest =:= <<>> ->
-            {?MQTT_RC_SUCCESS, #{}};
-        ?MQTTv5 ->
-            <<RC:8, Rest1/binary>> = Rest,
-            {ok, {Ps, <<>>}} = parse_properties(Rest1),
-            {RC, Ps};
-        _ when Rest =:= <<>> ->
-            {?MQTT_RC_SUCCESS, #{}}
-    end,
-    {ok, #{
-        type => 'pubrel',
-        packet_id => PacketId,
-        reason_code => ReasonCode,
-        properties => Properties
-    }};
-variable(MQTTVersion, <<?SUBSCRIBE:4, 0:2, 1:1, 0:1>>, <<PacketId:16/big, Rest/binary>>) ->
-    {ok, {Properties, Rest1}} = parse_properties(MQTTVersion, Rest),
-    case parse_subscribe_topics(Rest1, []) of
-        {ok, Topics} ->
+    case Res of
+        {ok, {ReasonCode, Properties}} ->
             {ok, #{
-                type => 'subscribe',
+                type => case P of
+                            ?PUBACK -> 'puback';
+                            ?PUBREC -> 'pubrec';
+                            ?PUBCOMP -> 'pubcomp'
+                        end,
                 packet_id => PacketId,
-                topics => Topics,
+                reason_code => ReasonCode,
                 properties => Properties
             }};
-        {error, _} = Error ->
-            Error
+        {error, _} = Err -> Err
+    end;
+variable(MQTTVersion, <<?PUBREL:4, 2:4>>, <<PacketId:16/big, Rest/binary>>) ->
+    Res = case MQTTVersion of
+        ?MQTTv5 when Rest =:= <<>> ->
+            {ok, {?MQTT_RC_SUCCESS, #{}}};
+        ?MQTTv5 ->
+            case Rest of
+                <<RC:8, Rest1/binary>> ->
+                    case parse_properties(Rest1) of
+                        {ok, {Ps, <<>>}} -> {ok, {RC, Ps}};
+                        {error, _} = ErrP -> ErrP
+                    end;
+                _ -> {error, incomplete_packet}
+            end;
+        _ when Rest =:= <<>> ->
+            {ok, {?MQTT_RC_SUCCESS, #{}}}
+    end,
+    case Res of
+        {ok, {ReasonCode, Properties}} ->
+            {ok, #{
+                type => 'pubrel',
+                packet_id => PacketId,
+                reason_code => ReasonCode,
+                properties => Properties
+            }};
+        {error, _} = Err -> Err
+    end;
+variable(MQTTVersion, <<?SUBSCRIBE:4, 0:2, 1:1, 0:1>>, <<PacketId:16/big, Rest/binary>>) ->
+    case parse_properties(MQTTVersion, Rest) of
+        {ok, {Properties, Rest1}} ->
+            case parse_subscribe_topics(Rest1, []) of
+                {ok, Topics} ->
+                    {ok, #{
+                        type => 'subscribe',
+                        packet_id => PacketId,
+                        topics => Topics,
+                        properties => Properties
+                    }};
+                {error, _} = ErrT ->
+                    ErrT
+            end;
+        {error, _} = ErrP -> ErrP
     end;
 variable(MQTTVersion, <<?SUBACK:4, 0:4>>, <<PacketId:16/big, Rest/binary>>) ->
-    {ok, {Properties, Rest1}} = parse_properties(MQTTVersion, Rest),
-    Acks = parse_acks(Rest1, []),
-    {ok, #{
-        type => 'suback',
-        packet_id => PacketId,
-        properties => Properties,
-        acks => Acks
-    }};
+    case parse_properties(MQTTVersion, Rest) of
+        {ok, {Properties, Rest1}} ->
+            case parse_acks(Rest1, []) of
+                {ok, Acks} ->
+                    {ok, #{
+                        type => 'suback',
+                        packet_id => PacketId,
+                        properties => Properties,
+                        acks => Acks
+                    }};
+                {error, _} = ErrA ->
+                    ErrA
+            end;
+        {error, _} = ErrP -> ErrP
+    end;
 variable(MQTTVersion, <<?UNSUBSCRIBE:4, 0:2, 1:1, 0:1>>, <<PacketId:16/big, Rest/binary>>) ->
-    {ok, {Properties, Rest1}} = parse_properties(MQTTVersion, Rest),
-    case parse_unsubscribe_topics(Rest1, []) of
-        {ok, Topics} ->
-            {ok, #{
-                type => 'unsubscribe',
-                packet_id => PacketId,
-                properties => Properties,
-                topics => Topics
-            }};
-        {error, _} = Error ->
-            Error
+    case parse_properties(MQTTVersion, Rest) of
+        {ok, {Properties, Rest1}} ->
+            case parse_unsubscribe_topics(Rest1, []) of
+                {ok, Topics} ->
+                    {ok, #{
+                        type => 'unsubscribe',
+                        packet_id => PacketId,
+                        properties => Properties,
+                        topics => Topics
+                    }};
+                {error, _} = ErrT ->
+                    ErrT
+            end;
+        {error, _} = ErrP -> ErrP
     end;
 variable(MQTTVersion, <<?UNSUBACK:4, 0:4>>, <<PacketId:16/big, Rest/binary>>) ->
-    {ok, {Properties, Rest1}} = parse_properties(MQTTVersion, Rest),
-    Acks = parse_unacks(Rest1, []),
-    {ok, #{
-        type => 'unsuback',
-        packet_id => PacketId,
-        properties => Properties,
-        acks => Acks
-    }};
+    case parse_properties(MQTTVersion, Rest) of
+        {ok, {Properties, Rest1}} ->
+            case parse_unacks(Rest1, []) of
+                {ok, Acks} ->
+                    {ok, #{
+                        type => 'unsuback',
+                        packet_id => PacketId,
+                        properties => Properties,
+                        acks => Acks
+                    }};
+                {error, _} = ErrA ->
+                    ErrA
+            end;
+        {error, _} = ErrP -> ErrP
+    end;
 variable(_MQTTVersion, <<?PINGREQ:4, 0:4>>, <<>>) ->
     {ok, #{
         type => 'pingreq'
@@ -252,12 +285,15 @@ variable(_MQTTVersion, <<?DISCONNECT:4, 0:4>>, <<>>) ->
         properties => #{}
     }};
 variable(MQTTVersion, <<?DISCONNECT:4, 0:4>>, <<Reason:8, Rest/binary>>) ->
-    {ok, {Properties, <<>>}} = parse_properties(MQTTVersion, Rest),
-    {ok, #{
-        type => 'disconnect',
-        reason_code => Reason,
-        properties => Properties
-    }};
+    case parse_properties(MQTTVersion, Rest) of
+        {ok, {Properties, <<>>}} ->
+            {ok, #{
+                type => 'disconnect',
+                reason_code => Reason,
+                properties => Properties
+            }};
+        {error, _} = ErrP -> ErrP
+    end;
 variable(?MQTTv5, <<?AUTH:4, 0:4>>, <<>>) ->
     {ok, #{
         type => 'auth',
@@ -265,12 +301,15 @@ variable(?MQTTv5, <<?AUTH:4, 0:4>>, <<>>) ->
         properties => #{}
     }};
 variable(?MQTTv5 = MQTTVersion, <<?AUTH:4, 0:4>>, <<Reason:8, Rest/binary>>) ->
-    {ok, {Properties, <<>>}} = parse_properties(MQTTVersion, Rest),
-    {ok, #{
-        type => 'auth',
-        reason_code => Reason,
-        properties => Properties
-    }};
+    case parse_properties(MQTTVersion, Rest) of
+        {ok, {Properties, <<>>}} ->
+            {ok, #{
+                type => 'auth',
+                reason_code => Reason,
+                properties => Properties
+            }};
+        {error, _} = ErrP -> ErrP
+    end;
 variable(_MQTTVersion, _Fixed, _Var) ->
     {error, invalid_packet}.
 
@@ -286,54 +325,131 @@ protocol_name_level(?PROTOCOL_NAME,   16#84) -> {true, ?MQTTv311};
 protocol_name_level(?PROTOCOL_NAME,   16#85) -> {true, ?MQTTv5};
 protocol_name_level(_, _) -> false.
 
+decode_connect_properties(Bin, Connect, UserNameFlag, PasswordFlag) ->
+    ProtoVersion = maps:get(protocol_version, Connect),
+    case parse_properties(ProtoVersion, Bin) of
+        {ok, {Properties, Rest}} ->
+            decode_connect_client_id(Rest, Connect#{ properties => Properties }, UserNameFlag, PasswordFlag);
+        {error, _} = Err -> Err
+    end.
+
+decode_connect_client_id(Bin, Connect, UserNameFlag, PasswordFlag) ->
+    case parse_utf(Bin) of
+        {ok, {ClientId, Rest}} ->
+            decode_connect_will_properties(Rest, Connect#{ client_id => ClientId }, UserNameFlag, PasswordFlag);
+        {error, _} = Err -> Err
+    end.
+
+decode_connect_will_properties(Bin, #{ will_flag := true, protocol_version := ProtoVersion } = Connect, UserNameFlag, PasswordFlag) ->
+    case parse_properties(ProtoVersion, Bin) of
+        {ok, {WillProperties, Rest}} ->
+            decode_connect_will_topic(Rest, Connect#{ will_properties => WillProperties }, UserNameFlag, PasswordFlag);
+        {error, _} = Err -> Err
+    end;
+decode_connect_will_properties(Bin, Connect, UserNameFlag, PasswordFlag) ->
+    decode_connect_will_topic(Bin, Connect#{ will_properties => #{} }, UserNameFlag, PasswordFlag).
+
+decode_connect_will_topic(Bin, #{ will_flag := true } = Connect, UserNameFlag, PasswordFlag) ->
+    case parse_utf(Bin) of
+        {ok, {WillTopic, Rest}} ->
+            case split_topic(WillTopic) of
+                {ok, WillTopicValidated} ->
+                    decode_connect_will_msg(Rest, Connect#{ will_topic => WillTopicValidated }, UserNameFlag, PasswordFlag);
+                {error, _} = Err -> Err
+            end;
+        {error, _} = Err -> Err
+    end;
+decode_connect_will_topic(Bin, Connect, UserNameFlag, PasswordFlag) ->
+    decode_connect_will_msg(Bin, Connect#{ will_topic => undefined }, UserNameFlag, PasswordFlag).
+
+decode_connect_will_msg(Bin, #{ will_flag := true } = Connect, UserNameFlag, PasswordFlag) ->
+    case parse_msg(Bin, 1) of
+        {ok, {WillPayload, Rest}} ->
+            decode_connect_username(Rest, Connect#{ will_payload => WillPayload }, UserNameFlag, PasswordFlag);
+        {error, _} = Err -> Err
+    end;
+decode_connect_will_msg(Bin, Connect, UserNameFlag, PasswordFlag) ->
+    decode_connect_username(Bin, Connect#{ will_payload => undefined }, UserNameFlag, PasswordFlag).
+
+decode_connect_username(Bin, Connect, 1, PasswordFlag) ->
+    case parse_utf(Bin) of
+        {ok, {Username, Rest}} ->
+            decode_connect_password(Rest, Connect#{ username => Username }, PasswordFlag);
+        {error, _} = Err -> Err
+    end;
+decode_connect_username(Bin, Connect, 0, PasswordFlag) ->
+    decode_connect_password(Bin, Connect#{ username => undefined }, PasswordFlag).
+
+decode_connect_password(Bin, Connect, 1) ->
+    case parse_utf(Bin) of
+        {ok, {Password, <<>>}} ->
+            {ok, Connect#{ password => Password }};
+        {ok, {_Password, _Rest}} ->
+            {error, malformed_packet};
+        {error, _} = Err -> Err
+    end;
+decode_connect_password(<<>>, Connect, 0) ->
+    {ok, Connect#{ password => undefined }};
+decode_connect_password(_Bin, _Connect, 0) ->
+    {error, malformed_packet}.
 
 
 parse_subscribe_topics(<<>>, Topics) ->
     {ok, lists:reverse(Topics)};
 parse_subscribe_topics(Bin, Topics) ->
-    {Name, OptRest} = parse_utf(Bin),
-    <<0:2, RH:2, RAP:1, NL:1, QoS:2, Rest/binary>> = OptRest,
-    case split_topic(Name) of
-        {ok, NameValidated} ->
-            T = #{
-                topic => NameValidated,
-                retain_handling => RH,
-                retain_as_published => bool(RAP),
-                no_local => bool(NL),
-                qos => qos(QoS)
-            },
-            parse_subscribe_topics(Rest, [ T | Topics ]);
-        {error, _} = Error ->
-            Error
+    case parse_utf(Bin) of
+        {ok, {Name, <<0:2, RH:2, RAP:1, NL:1, QoS:2, Rest/binary>>}} ->
+            case split_topic(Name) of
+                {ok, NameValidated} ->
+                    T = #{
+                        topic => NameValidated,
+                        retain_handling => RH,
+                        retain_as_published => bool(RAP),
+                        no_local => bool(NL),
+                        qos => qos(QoS)
+                    },
+                    parse_subscribe_topics(Rest, [ T | Topics ]);
+                {error, _} = ErrT ->
+                    ErrT
+            end;
+        {ok, _} -> {error, malformed_packet};
+        {error, _} = ErrUTF -> ErrUTF
     end.
 
 parse_unsubscribe_topics(<<>>, Topics) ->
     {ok, lists:reverse(Topics)};
 parse_unsubscribe_topics(Bin, Topics) ->
-    {Name, Rest} = parse_utf(Bin),
-    case split_topic(Name) of
-        {ok, NameValidated} ->
-            parse_unsubscribe_topics(Rest, [ NameValidated | Topics ]);
-        {error, _} = Error ->
-            Error
+    case parse_utf(Bin) of
+        {ok, {Name, Rest}} ->
+            case split_topic(Name) of
+                {ok, NameValidated} ->
+                    parse_unsubscribe_topics(Rest, [ NameValidated | Topics ]);
+                {error, _} = ErrT ->
+                    ErrT
+            end;
+        {error, _} = ErrUTF -> ErrUTF
     end.
 
 
 parse_acks(<<>>, Acks) ->
-    lists:reverse(Acks);
+    {ok, lists:reverse(Acks)};
 parse_acks(<<0:6, QoS:2, Rest/binary>>, Acks) ->
     parse_acks(Rest, [ {ok, qos(QoS)} | Acks]);
-parse_acks(<<Reason:8, Rest/binary>>, Acks) when Reason >= 16#80 ->
-    parse_acks(Rest, [ {error, Reason} | Acks]).
+parse_acks(<<Reason:8, Rest/binary>>, Acks) ->
+    parse_acks(Rest, [ {error, Reason} | Acks]);
+parse_acks(_, _) ->
+    {error, incomplete_packet}.
 
 parse_unacks(<<>>, Acks) ->
-    lists:reverse(Acks);
+    {ok, lists:reverse(Acks)};
 parse_unacks(<<0, Rest/binary>>, Acks) ->
     parse_unacks(Rest, [ {ok, found} | Acks]);
 parse_unacks(<<17, Rest/binary>>, Acks) ->
     parse_unacks(Rest, [ {ok, notfound} | Acks]);
-parse_unacks(<<Reason:8, Rest/binary>>, Acks) when Reason >= 16#80 ->
-    parse_unacks(Rest, [ {error, Reason} | Acks]).
+parse_unacks(<<Reason:8, Rest/binary>>, Acks) ->
+    parse_unacks(Rest, [ {error, Reason} | Acks]);
+parse_unacks(_, _) ->
+    {error, incomplete_packet}.
 
 
 %%%%%
@@ -350,66 +466,87 @@ parse_properties(<<>>) ->
     {ok, {#{}, <<>>}};
 parse_properties(Bin) ->
     case parse_varint(Bin) of
+        {ok, {Len, Bin1}} ->
+            case Bin1 of
+                <<PropBin:Len/binary, Rest/binary>> ->
+                    case parse_property(PropBin, #{}) of
+                        {ok, Props} ->
+                            {ok, {Props, Rest}};
+                        {error, _} = Error ->
+                            Error
+                    end;
+                _ ->
+                    {error, incomplete_packet}
+            end;
         {error, _} = Error ->
-            Error;
-        {Len, Bin1} ->
-            <<PropBin:Len/binary, Rest/binary>> = Bin1,
-            case parse_property(PropBin, #{}) of
-                {ok, Props} ->
-                    {ok, {Props, Rest}};
-                {error, _} = Error ->
-                    Error
-            end
+            Error
     end.
 
 parse_property(<<>>, Props) ->
-    {ok, Props};
+    Props1 = case maps:get('subscription_identifier', Props, undefined) of
+                 Vs when is_list(Vs) -> Props#{ 'subscription_identifier' => lists:reverse(Vs) };
+                 _ -> Props
+             end,
+    {ok, Props1};
 parse_property(<<16#01, Val:8, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'payload_format_indicator' => bool(Val) });
 parse_property(<<16#02, Val:32/big, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'message_expiry_interval' => Val });
 parse_property(<<16#03, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_utf(Bin),
-    parse_property(Rest, Props#{ 'content_type' => Val });
+    case parse_utf(Bin) of
+        {ok, {Val, Rest}} -> parse_property(Rest, Props#{ 'content_type' => Val });
+        {error, _} = ErrUTF -> ErrUTF
+    end;
 parse_property(<<16#08, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_utf(Bin),
-    case split_topic(Val) of
-        {ok, TopicValidated} ->
-            parse_property(Rest, Props#{ 'response_topic' => TopicValidated });
-        {error, _} = Error ->
-            Error
+    case parse_utf(Bin) of
+        {ok, {Val, Rest}} ->
+            case split_topic(Val) of
+                {ok, TopicValidated} ->
+                    parse_property(Rest, Props#{ 'response_topic' => TopicValidated });
+                {error, _} = ErrT ->
+                    ErrT
+            end;
+        {error, _} = ErrUTF -> ErrUTF
     end;
 parse_property(<<16#09, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_bin(Bin),
-    parse_property(Rest, Props#{ 'correlation_data' => Val });
+    case parse_bin(Bin) of
+        {ok, {Val, Rest}} -> parse_property(Rest, Props#{ 'correlation_data' => Val });
+        {error, _} = ErrBin -> ErrBin
+    end;
 parse_property(<<16#0B, Bin/binary>>, Props) ->
     case parse_varint(Bin) of
-        {error, _} = Error ->
-            Error;
-        {Val, Rest} ->
+        {ok, {Val, Rest}} ->
             Props1 = case maps:get('subscription_identifier', Props, undefined) of
                          undefined ->
                              Props#{ 'subscription_identifier' => Val };
                          Vs when is_list(Vs) ->
-                             Props#{ 'subscription_identifier' => Vs ++ [ Val ] };
+                             Props#{ 'subscription_identifier' => [ Val | Vs ] };
                          V when is_integer(V) ->
-                             Props#{ 'subscription_identifier' => [ V, Val ] }
+                             Props#{ 'subscription_identifier' => [ Val, V ] }
                      end,
-            parse_property(Rest, Props1)
+            parse_property(Rest, Props1);
+        {error, _} = Error ->
+            Error
     end;
 parse_property(<<16#11, Val:32/big, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'session_expiry_interval' => Val });
 parse_property(<<16#12, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_utf(Bin),
-    parse_property(Rest, Props#{ 'assigned_client_identifier' => Val });
+    case parse_utf(Bin) of
+        {ok, {Val, Rest}} -> parse_property(Rest, Props#{ 'assigned_client_identifier' => Val });
+        {error, _} = ErrUTF -> ErrUTF
+    end;
 parse_property(<<16#13, Val:16/big, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'server_keep_alive' => Val });
 parse_property(<<16#15, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_utf(Bin),
-    parse_property(Rest, Props#{ 'authentication_method' => Val });
+    case parse_utf(Bin) of
+        {ok, {Val, Rest}} -> parse_property(Rest, Props#{ 'authentication_method' => Val });
+        {error, _} = ErrUTF -> ErrUTF
+    end;
 parse_property(<<16#16, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_bin(Bin),
-    parse_property(Rest, Props#{ 'authentication_data' => Val });
+    case parse_bin(Bin) of
+        {ok, {Val, Rest}} -> parse_property(Rest, Props#{ 'authentication_data' => Val });
+        {error, _} = ErrBin -> ErrBin
+    end;
 parse_property(<<16#17, Val:8, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{'request_problem_information' => bool(Val) });
 parse_property(<<16#18, Val:32/big, Rest/binary>>, Props) ->
@@ -417,14 +554,20 @@ parse_property(<<16#18, Val:32/big, Rest/binary>>, Props) ->
 parse_property(<<16#19, Val:8, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'request_response_information' => bool(Val)});
 parse_property(<<16#1A, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_utf(Bin),
-    parse_property(Rest, Props#{ 'response_information' => Val });
+    case parse_utf(Bin) of
+        {ok, {Val, Rest}} -> parse_property(Rest, Props#{ 'response_information' => Val });
+        {error, _} = ErrUTF -> ErrUTF
+    end;
 parse_property(<<16#1C, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_utf(Bin),
-    parse_property(Rest, Props#{ 'server_reference' => Val });
+    case parse_utf(Bin) of
+        {ok, {Val, Rest}} -> parse_property(Rest, Props#{ 'server_reference' => Val });
+        {error, _} = ErrUTF -> ErrUTF
+    end;
 parse_property(<<16#1F, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_utf(Bin),
-    parse_property(Rest, Props#{ 'reason_string' => Val });
+    case parse_utf(Bin) of
+        {ok, {Val, Rest}} -> parse_property(Rest, Props#{ 'reason_string' => Val });
+        {error, _} = ErrUTF -> ErrUTF
+    end;
 parse_property(<<16#21, Val:16/big, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'receive_maximum' => Val});
 parse_property(<<16#22, Val:16/big, Rest/binary>>, Props) ->
@@ -437,8 +580,10 @@ parse_property(<<16#25, Val:8, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'retain_available' => bool(Val) });
 parse_property(<<16#26, Bin/binary>>, Props) ->
     % User properties use binary keys in the properties map
-    {{Key, Val}, Rest} = parse_utf_pair(Bin),
-    parse_property(Rest, Props#{ Key => Val });
+    case parse_utf_pair(Bin) of
+        {ok, {{Key, Val}, Rest}} -> parse_property(Rest, Props#{ Key => Val });
+        {error, _} = ErrUTFP -> ErrUTFP
+    end;
 parse_property(<<16#27, Val:32/big, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'maximum_packet_size' => Val });
 parse_property(<<16#28, Val:8, Rest/binary>>, Props) ->
@@ -446,7 +591,11 @@ parse_property(<<16#28, Val:8, Rest/binary>>, Props) ->
 parse_property(<<16#29, Val:8, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'subscription_identifier_available' => bool(Val) });
 parse_property(<<16#2A, Val:8, Rest/binary>>, Props) ->
-    parse_property(Rest, Props#{ 'shared_subscription_available' => bool(Val) }).
+    parse_property(Rest, Props#{ 'shared_subscription_available' => bool(Val) });
+parse_property(<<ID:8, _/binary>>, _Props) ->
+    {error, {unknown_property, ID}};
+parse_property(<<>>, _Props) ->
+    {error, incomplete_packet}.
 
 parse_varint(B) ->
     parse_varint(B, 0, 0).
@@ -456,7 +605,7 @@ parse_varint(<<>>, _Count, _Value) ->
 parse_varint(<<0:1, 0:7, _Rest/binary>>, Count, _Value) when Count > 0 ->
     {error, malformed_packet};
 parse_varint(<<0:1, I:7, Rest/binary>>, Count, Value) ->
-    {Value + (I bsl (Count * 7)), Rest};
+    {ok, {Value + (I bsl (Count * 7)), Rest}};
 parse_varint(<<1:1, I:7, Rest/binary>>, Count, Value) when Count < (?MAX_VARINT_BYTES - 1) ->
     parse_varint(Rest, Count + 1, Value + (I bsl (Count * 7)));
 parse_varint(<<1:1, _I:7, _Rest/binary>>, _Count, _Value) ->
@@ -469,25 +618,31 @@ split_topic(Topic) ->
     mqtt_packet_map_topic:validate_topic(Topic).
 
 parse_utf_pair(Bin) ->
-    {Key, Bin1} = parse_utf(Bin),
-    {Val, Rest} = parse_utf(Bin1),
-    {{Key, Val}, Rest}.
-
-parse_utf(Bin, 0) ->
-    {undefined, Bin};
-parse_utf(Bin, 1) ->
-    parse_utf(Bin).
+    case parse_utf(Bin) of
+        {ok, {Key, Bin1}} ->
+            case parse_utf(Bin1) of
+                {ok, {Val, Rest}} -> {ok, {{Key, Val}, Rest}};
+                {error, _} = ErrUTF -> ErrUTF
+            end;
+        {error, _} = ErrUTF -> ErrUTF
+    end.
 
 parse_utf(<<Len:16/big, Str:Len/binary, Rest/binary>>) ->
-    {Str, Rest}.
+    {ok, {Str, Rest}};
+parse_utf(Bin) when is_binary(Bin) ->
+    {error, incomplete_packet}.
 
 parse_msg(Bin, 0) ->
-    {undefined, Bin};
+    {ok, {undefined, Bin}};
 parse_msg(<<Len:16/big, Msg:Len/binary, Rest/binary>>, _) ->
-    {Msg, Rest}.
+    {ok, {Msg, Rest}};
+parse_msg(Bin, _) when is_binary(Bin) ->
+    {error, incomplete_packet}.
 
 parse_bin(<<Len:16/big, Bin:Len/binary, Rest/binary>>) ->
-    {Bin, Rest}.
+    {ok, {Bin, Rest}};
+parse_bin(Bin) when is_binary(Bin) ->
+    {error, incomplete_packet}.
 
 bool(0) -> false;
 bool(1) -> true.

--- a/src/mqtt_packet_map_decoder.erl
+++ b/src/mqtt_packet_map_decoder.erl
@@ -29,10 +29,14 @@
     parse_varint/1
     ]).
 
+
+
 -include("mqtt_packet_map_defs.hrl").
 -include("mqtt_packet_map.hrl").
 
 -type decode_return() :: {ok, {mqtt_packet_map:mqtt_packet(), binary()}} | {error, mqtt_packet_map:decode_error()}.
+
+-define(MAX_VARINT_BYTES, 4).
 
 %% @doc Decode an incoming MQTT packet, returns a decoded packet or an error.
 -spec decode( mqtt_packet_map:mqtt_version(), binary() ) -> decode_return().
@@ -345,13 +349,17 @@ parse_properties(_ProtoVersion, PropsRest) ->
 parse_properties(<<>>) ->
     {ok, {#{}, <<>>}};
 parse_properties(Bin) ->
-    {Len, Bin1} = parse_varint(Bin),
-    <<PropBin:Len/binary, Rest/binary>> = Bin1,
-    case parse_property(PropBin, #{}) of
-        {ok, Props} ->
-            {ok, {Props, Rest}};
+    case parse_varint(Bin) of
         {error, _} = Error ->
-            Error
+            Error;
+        {Len, Bin1} ->
+            <<PropBin:Len/binary, Rest/binary>> = Bin1,
+            case parse_property(PropBin, #{}) of
+                {ok, Props} ->
+                    {ok, {Props, Rest}};
+                {error, _} = Error ->
+                    Error
+            end
     end.
 
 parse_property(<<>>, Props) ->
@@ -375,16 +383,20 @@ parse_property(<<16#09, Bin/binary>>, Props) ->
     {Val, Rest} = parse_bin(Bin),
     parse_property(Rest, Props#{ 'correlation_data' => Val });
 parse_property(<<16#0B, Bin/binary>>, Props) ->
-    {Val, Rest} = parse_varint(Bin),
-    Props1 = case maps:get('subscription_identifier', Props, undefined) of
-        undefined ->
-            Props#{ 'subscription_identifier' => Val };
-        Vs when is_list(Vs) ->
-            Props#{ 'subscription_identifier' => Vs ++ [ Val ] };
-        V when is_integer(V) ->
-            Props#{ 'subscription_identifier' => [ V, Val ] }
-    end,
-    parse_property(Rest, Props1);
+    case parse_varint(Bin) of
+        {error, _} = Error ->
+            Error;
+        {Val, Rest} ->
+            Props1 = case maps:get('subscription_identifier', Props, undefined) of
+                         undefined ->
+                             Props#{ 'subscription_identifier' => Val };
+                         Vs when is_list(Vs) ->
+                             Props#{ 'subscription_identifier' => Vs ++ [ Val ] };
+                         V when is_integer(V) ->
+                             Props#{ 'subscription_identifier' => [ V, Val ] }
+                     end,
+            parse_property(Rest, Props1)
+    end;
 parse_property(<<16#11, Val:32/big, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'session_expiry_interval' => Val });
 parse_property(<<16#12, Bin/binary>>, Props) ->
@@ -436,15 +448,20 @@ parse_property(<<16#29, Val:8, Rest/binary>>, Props) ->
 parse_property(<<16#2A, Val:8, Rest/binary>>, Props) ->
     parse_property(Rest, Props#{ 'shared_subscription_available' => bool(Val) }).
 
-
-
 parse_varint(B) ->
     parse_varint(B, 0, 0).
 
-parse_varint(<<0:1, I:7, Rest/binary>>, Shift, Value) ->
-    {Value + (I bsl Shift), Rest};
-parse_varint(<<1:1, I:7, Rest/binary>>, Shift, Value) ->
-    parse_varint(Rest, Shift + 7, Value + (I bsl Shift)).
+parse_varint(<<>>, _Count, _Value) ->
+    {error, incomplete_packet};
+parse_varint(<<0:1, 0:7, _Rest/binary>>, Count, _Value) when Count > 0 ->
+    {error, malformed_packet};
+parse_varint(<<0:1, I:7, Rest/binary>>, Count, Value) ->
+    {Value + (I bsl (Count * 7)), Rest};
+parse_varint(<<1:1, I:7, Rest/binary>>, Count, Value) when Count < (?MAX_VARINT_BYTES - 1) ->
+    parse_varint(Rest, Count + 1, Value + (I bsl (Count * 7)));
+parse_varint(<<1:1, _I:7, _Rest/binary>>, _Count, _Value) ->
+    {error, malformed_packet}.
+
 
 split_topic(undefined) ->
     {ok, undefined};

--- a/src/mqtt_packet_map_decoder.erl
+++ b/src/mqtt_packet_map_decoder.erl
@@ -363,7 +363,7 @@ decode_connect_will_topic(Bin, Connect, UserNameFlag, PasswordFlag) ->
     decode_connect_will_msg(Bin, Connect#{ will_topic => undefined }, UserNameFlag, PasswordFlag).
 
 decode_connect_will_msg(Bin, #{ will_flag := true } = Connect, UserNameFlag, PasswordFlag) ->
-    case parse_msg(Bin, 1) of
+    case parse_bin(Bin) of
         {ok, {WillPayload, Rest}} ->
             decode_connect_username(Rest, Connect#{ will_payload => WillPayload }, UserNameFlag, PasswordFlag);
         {error, _} = Err -> Err
@@ -612,8 +612,6 @@ parse_varint(<<1:1, _I:7, _Rest/binary>>, _Count, _Value) ->
     {error, malformed_packet}.
 
 
-split_topic(undefined) ->
-    {ok, undefined};
 split_topic(Topic) ->
     mqtt_packet_map_topic:validate_topic(Topic).
 
@@ -630,13 +628,6 @@ parse_utf_pair(Bin) ->
 parse_utf(<<Len:16/big, Str:Len/binary, Rest/binary>>) ->
     {ok, {Str, Rest}};
 parse_utf(Bin) when is_binary(Bin) ->
-    {error, incomplete_packet}.
-
-parse_msg(Bin, 0) ->
-    {ok, {undefined, Bin}};
-parse_msg(<<Len:16/big, Msg:Len/binary, Rest/binary>>, _) ->
-    {ok, {Msg, Rest}};
-parse_msg(Bin, _) when is_binary(Bin) ->
     {error, incomplete_packet}.
 
 parse_bin(<<Len:16/big, Bin:Len/binary, Rest/binary>>) ->

--- a/src/mqtt_packet_map_topic.erl
+++ b/src/mqtt_packet_map_topic.erl
@@ -107,13 +107,7 @@ flatten_topic(B) when is_binary(B) ->
 flatten_topic([]) ->
     <<>>;
 flatten_topic([ H | T ]) ->
-    flatten_topic_list(T, to_binary(H)).
-
-flatten_topic_list([], Acc) ->
-    Acc;
-flatten_topic_list([ H  | T ], Acc) ->
-    H1 = to_binary(H),
-    flatten_topic_list(T, <<Acc/binary, $/, H1/binary>>).
+    iolist_to_binary([ to_binary(H) | [ [$/, to_binary(P)] || P <- T ] ]).
 
 -spec is_wildcard_topic( list() ) -> boolean().
 is_wildcard_topic(L) ->

--- a/test/mqtt_packet_map_SUITE.erl
+++ b/test/mqtt_packet_map_SUITE.erl
@@ -51,12 +51,12 @@ variable_byte_integer(_Config) ->
     <<16#80, 16#80, 16#80, 16#01>> = mqtt_packet_map_encoder:varint(2097152),
     <<16#FF, 16#FF, 16#FF, 16#7F>> = mqtt_packet_map_encoder:varint(16#0fffffff),
 
-    {0, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(0) ),
-    {1, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(1) ),
-    {127, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(127) ),
-    {128, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(128) ),
-    {123456789, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(123456789) ),
-    {16#0fffffff, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(16#0fffffff) ),
+    {ok, {0, <<>>}} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(0) ),
+    {ok, {1, <<>>}} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(1) ),
+    {ok, {127, <<>>}} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(127) ),
+    {ok, {128, <<>>}} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(128) ),
+    {ok, {123456789, <<>>}} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(123456789) ),
+    {ok, {16#0fffffff, <<>>}} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(16#0fffffff) ),
 
     ok.
 

--- a/test/mqtt_packet_map_SUITE.erl
+++ b/test/mqtt_packet_map_SUITE.erl
@@ -22,6 +22,7 @@ end_per_testcase(_TestCase, _Config) ->
 all() ->
     [
         variable_byte_integer,
+        malformed_variable_byte_integer,
         packet_size,
         partial_packet,
         connect_v5,
@@ -48,12 +49,28 @@ variable_byte_integer(_Config) ->
     <<16#7F>> = mqtt_packet_map_encoder:varint(127),
     <<16#80, 16#01>> = mqtt_packet_map_encoder:varint(128),
     <<16#80, 16#80, 16#80, 16#01>> = mqtt_packet_map_encoder:varint(2097152),
+    <<16#FF, 16#FF, 16#FF, 16#7F>> = mqtt_packet_map_encoder:varint(16#0fffffff),
+
     {0, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(0) ),
     {1, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(1) ),
     {127, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(127) ),
     {128, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(128) ),
-    {1234567890, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(1234567890) ),
-    {16#7fffffff, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(16#7fffffff) ),
+    {123456789, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(123456789) ),
+    {16#0fffffff, <<>>} = mqtt_packet_map_decoder:parse_varint( mqtt_packet_map_encoder:varint(16#0fffffff) ),
+
+    ok.
+
+malformed_variable_byte_integer(_Config) ->
+    {error, incomplete_packet} = mqtt_packet_map_decoder:parse_varint(<<>>),
+
+    % non-minimal encodings
+    {error, malformed_packet} = mqtt_packet_map_decoder:parse_varint(<<16#80, 16#00>>),
+    {error, malformed_packet} = mqtt_packet_map_decoder:parse_varint(<<16#80, 16#80, 16#00>>),
+    {error, malformed_packet} = mqtt_packet_map_decoder:parse_varint(<<16#80, 16#80, 16#80, 16#00>>),
+
+    % varints can be 4 bytes long maximum
+    {error, malformed_packet} = mqtt_packet_map_decoder:parse_varint(<<16#FF, 16#FF, 16#FF, 16#FF, 16#7F>>),
+
     ok.
 
 packet_size(_Config) ->


### PR DESCRIPTION
The parser accepted varints longer than 4 bytes, which is not allowed.